### PR TITLE
Several fixes to make it work as a drop in replacement for roscore

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"]}
 url = "2.3.1"
 maplit = "1.0.2"
 futures = "0.3.30"
+uuid = { version = "1.10.0", features = ["v1", "rng"] }
 
 [dev-dependencies]
 rosrust = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,12 @@ keywords = ["ros", "rosrust", "roscore", "robotics"]
 categories = ["science::robotics"]
 
 [dependencies]
-dxr = { path = "../dxr/dxr" }
-dxr_server = { path = "../dxr/dxr_server", features = ["axum", "multicall"] }
-dxr_client = { path = "../dxr/dxr_client", default-features = false, features = ["reqwest", "rustls-tls"] }
+dxr = { version = "0.6.3" }
+dxr_server = { version = "0.6.3", features = ["axum", "multicall"] }
+dxr_client = { version = "0.6.3", default-features = false, features = [
+    "reqwest",
+    "rustls-tls" # Use rustls instead of openssl for easier cross-compilation
+] }
 anyhow = "1.0.69"
 log = "0.4.17"
 env_logger = "0.10.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,9 @@ keywords = ["ros", "rosrust", "roscore", "robotics"]
 categories = ["science::robotics"]
 
 [dependencies]
-dxr = { version = "0.5.3", features = ["server", "server-axum"] }
+dxr = { path = "../dxr/dxr" }
+dxr_server = { path = "../dxr/dxr_server", features = ["axum", "multicall"] }
+dxr_client = { path = "../dxr/dxr_client", features = ["reqwest"] }
 anyhow = "1.0.69"
 log = "0.4.17"
 env_logger = "0.10.0"
@@ -20,6 +22,8 @@ chrono = "0.4.24"
 paste = "1.0.12"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"]}
 url = "2.3.1"
+maplit = "1.0.2"
+futures = "0.3.30"
 
 [dev-dependencies]
 rosrust = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["science::robotics"]
 [dependencies]
 dxr = { path = "../dxr/dxr" }
 dxr_server = { path = "../dxr/dxr_server", features = ["axum", "multicall"] }
-dxr_client = { path = "../dxr/dxr_client", features = ["reqwest"] }
+dxr_client = { path = "../dxr/dxr_client", default-features = false, features = ["reqwest", "rustls-tls"] }
 anyhow = "1.0.69"
 log = "0.4.17"
 env_logger = "0.10.0"

--- a/README.md
+++ b/README.md
@@ -71,3 +71,12 @@ necessary to use this script to use the standalone implementation on its own.
 We welcome contributions to this project! If you find a bug or have a feature
 request, please create an issue on the GitHub repository. If you want to
 contribute code, feel free to submit a pull request.
+
+
+## Cross-compilation to arm64
+```bash
+apt install libssl-dev:arm64
+export AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR=/usr/lib/aarch64-linux-gnu/
+export AARCH64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR=/usr/include/aarch64-linux-gnu/
+cargo build --target aarch64-unknown-linux-gnu --release
+```

--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -1,5 +1,5 @@
-use dxr_client::{Call, Client, ClientBuilder, Url};
 use dxr::Value;
+use dxr_client::{Call, Client, ClientBuilder, Url};
 
 pub struct ClientApi {
     client: Client,

--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -1,4 +1,4 @@
-use dxr::client::{Call, Client, ClientBuilder, Url};
+use dxr_client::{Call, Client, ClientBuilder, Url};
 use dxr::Value;
 
 pub struct ClientApi {
@@ -42,8 +42,8 @@ impl ClientApi {
         publisher_apis: &Vec<String>,
     ) -> anyhow::Result<()> {
         let request = Call::new("publisherUpdate", (caller_id, topic, publisher_apis));
-        let result = self.client.call(request).await;
-        result
+        let result = self.client.call::<_, ()>(request).await;
+        Ok(result?)
     }
 
     /// Sends a "paramUpdate" request to the ROS node.
@@ -65,6 +65,6 @@ impl ClientApi {
     ) -> anyhow::Result<()> {
         let request = Call::new("paramUpdate", (caller_id, key, value));
         let result = self.client.call(request).await;
-        result
+        Ok(result?)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@ pub mod core;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use url::Url;
 
+mod param_tree;
+
 pub fn url_to_socket_addr(url: &Url) -> anyhow::Result<SocketAddr> {
     let ip_addr = match url.host() {
         Some(url::Host::Domain(domain)) if domain == "localhost" => IpAddr::V4(Ipv4Addr::LOCALHOST),

--- a/src/param_tree.rs
+++ b/src/param_tree.rs
@@ -1,0 +1,172 @@
+use std::{any::Any, collections::HashMap, iter::Peekable, mem};
+
+use dxr::{TryFromParams, TryFromValue, TryToValue, Value};
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum ParamValue {
+    HashMap(HashMap<String, ParamValue>),
+    Array(Vec<ParamValue>),
+    Value(Value),
+}
+
+impl From<&Value> for ParamValue {
+    fn from(value: &Value) -> Self {
+        if let (Ok(hm)) = HashMap::<String, Value>::try_from_value(value) {
+            let mut rv = HashMap::with_capacity(hm.len());
+            for (k, v) in hm.into_iter() {
+                rv.insert(k, ParamValue::from(&v));
+            }
+            return Self::HashMap(rv);
+        }
+        if let (Ok(vec)) = Vec::<Value>::try_from_value(value) {
+            let mut rv = Vec::with_capacity(vec.len());
+            for e in vec.into_iter() {
+                rv.push(ParamValue::from(&e))
+            }
+            return Self::Array(rv);
+        }
+        Self::Value(value.clone())
+    }
+}
+
+impl TryToValue for ParamValue {
+    fn try_to_value(&self) -> Result<Value, dxr::DxrError> {
+        match self {
+            ParamValue::Value(v) => Ok(v.clone()),
+            ParamValue::Array(arr) => arr.try_to_value(),
+            ParamValue::HashMap(hm) => hm.try_to_value(),
+        }
+    }
+}
+
+impl ParamValue {
+    pub(crate) fn get_keys(&self) -> Vec<String> {
+        match self {
+            ParamValue::HashMap(hm) => {
+                let mut keys = Vec::new();
+                for (k, v) in hm.iter() {
+                    keys.push(format!("/{k}"));
+                    for suffix in v.get_keys() {
+                        keys.push(format!("/{k}{suffix}"));
+                    }
+                }
+                keys
+            }
+            _ => Vec::new(),
+        }
+    }
+    pub(crate) fn get<I, T>(&self, key: I) -> Option<Value>
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<str>,
+    {
+        let mut hm = self;
+        for e in key.into_iter() {
+            let e = e.as_ref();
+            if e == "" {
+                continue;
+            }
+            match hm {
+                ParamValue::HashMap(inner) => {
+                    if let Some(inner_value) = inner.get(e) {
+                        hm = inner_value;
+                    } else {
+                        return None;
+                    }
+                }
+                _ => return None,
+            }
+        }
+        Some(hm.try_to_value().unwrap())
+    }
+
+    pub(crate) fn remove<I, T>(&mut self, key: I)
+    where
+        I: IntoIterator<Item = T>,
+        T: AsRef<str>,
+    {
+        let mut peekable = key.into_iter().peekable();
+        match self {
+            ParamValue::HashMap(inner) => {
+                let mut hm = inner;
+                loop {
+                    let current_key = peekable.next();
+                    let next_key = peekable.peek();
+                    match (current_key, next_key) {
+                        (Some(current_key), None) => {
+                            hm.remove(current_key.as_ref());
+                            return;
+                        }
+                        (None, None) => {
+                            let _ = mem::replace(self, ParamValue::HashMap(hashmap! {}));
+                            return;
+                        }
+                        (None, Some(_)) => unreachable!(),
+                        (Some(current_key), Some(_)) => match hm.get_mut(current_key.as_ref()) {
+                            Some(ParamValue::HashMap(new_hm)) => hm = new_hm,
+                            _ => return,
+                        },
+                    }
+                }
+            }
+            _ => (),
+        }
+    }
+
+    pub(crate) fn update_inner<I, T>(&mut self, mut key: I, value: Value)
+    where
+        I: Iterator<Item = T>,
+        T: AsRef<str>,
+    {
+        match key.next() {
+            None => {
+                let _ = mem::replace(self, ParamValue::from(&value));
+            }
+            Some(next_key) => match self {
+                ParamValue::HashMap(hm) => match hm.get_mut(next_key.as_ref()) {
+                    Some(inner) => inner.update_inner(key, value),
+                    None => {
+                        hm.insert(next_key.as_ref().to_string(), {
+                            let mut inner = ParamValue::HashMap(HashMap::new());
+                            inner.update_inner(key, value);
+                            inner
+                        });
+                    }
+                },
+                _ => {
+                    let mut inner = ParamValue::HashMap(hashmap! {});
+                    inner.update_inner(key, value);
+                    let outer = ParamValue::HashMap(hashmap! {
+                        next_key.as_ref().to_string() => inner
+                    });
+                    let _ = mem::replace(self, outer);
+                }
+            },
+        }
+    }
+}
+
+use maplit::hashmap;
+
+#[test]
+fn test_param_tree() {
+    let mut tree = ParamValue::HashMap(hashmap! {
+        "run_id".to_owned() => ParamValue::Value(Value::string("asdf-jkl0".to_owned())),
+        "robot_id".to_owned() => ParamValue::Value(Value::i4(42)),
+        "robot_configs".to_owned() => ParamValue::Array(vec![
+            ParamValue::HashMap(hashmap! {
+                "robot_speed".to_owned() => ParamValue::Value(Value::double(3.0)),
+                "robot_id".to_owned() => ParamValue::Value(Value::i4(24))
+            })
+        ]),
+        "arms".to_owned() => ParamValue::HashMap(hashmap! {
+            "arm_left".to_owned() => ParamValue::HashMap(hashmap! {
+                "length".to_owned() => ParamValue::Value(Value::double(-0.45))
+            })
+        })
+    });
+
+    tree.update_inner(["robot_configs"].iter(), Value::i4(23));
+    let res = tree.get(["robot_configs"]).unwrap();
+    assert_eq!(res, Value::i4(23));
+}

--- a/src/param_tree.rs
+++ b/src/param_tree.rs
@@ -1,9 +1,9 @@
-use std::{any::Any, collections::HashMap, iter::Peekable, mem};
+use std::{collections::HashMap, mem};
 
-use dxr::{TryFromParams, TryFromValue, TryToValue, Value};
+use dxr::{TryFromValue, TryToValue, Value};
 
 #[derive(Debug, PartialEq)]
-pub(crate) enum ParamValue {
+pub enum ParamValue {
     HashMap(HashMap<String, ParamValue>),
     Array(Vec<ParamValue>),
     Value(Value),
@@ -11,14 +11,14 @@ pub(crate) enum ParamValue {
 
 impl From<&Value> for ParamValue {
     fn from(value: &Value) -> Self {
-        if let (Ok(hm)) = HashMap::<String, Value>::try_from_value(value) {
+        if let Ok(hm) = HashMap::<String, Value>::try_from_value(value) {
             let mut rv = HashMap::with_capacity(hm.len());
             for (k, v) in hm.into_iter() {
                 rv.insert(k, ParamValue::from(&v));
             }
             return Self::HashMap(rv);
         }
-        if let (Ok(vec)) = Vec::<Value>::try_from_value(value) {
+        if let Ok(vec) = Vec::<Value>::try_from_value(value) {
             let mut rv = Vec::with_capacity(vec.len());
             for e in vec.into_iter() {
                 rv.push(ParamValue::from(&e))


### PR DESCRIPTION
Hi,

thank you for the RiiR :)

I found a few issues / behavior differences from the original roscore implementation and fixed them, so that ros-core-rs can be used as a drop-in replacement.

Things i changed:
- correct handling of parameter tree queries / editing, especially nested structures
- correct use of namespaces
- upgraded the dependency to dxr [for a necessary bugfix](https://github.com/ironthree/dxr/issues/19)
- add a /run_id parameter on startup, using a similar implementation as upstream roscore
- correct implementation of the SearchParam API call (this was implemented as an alias for GetParam, but it's actually something else and robot_state_publisher needs this)
- configure dxr-client to use rustls instead of openssl, to support easy cross-compilation from x86_64 to aarch64. I'm not sure whether ros-core-rs even uses the TLS stuff.

While the test coverage is not extensive, we have tested this in our existing robot and so far have not found any more bugs. CPU usage is reduced significantly compared to the upstream roscore implementation in scenarios that put load on roscore, such as repeated querying for parameters. Incidentally, ros-core-rs's logs (with `RUST_LOG=ros_core_rs=debug`) turned out to be more useful than the log file of the original implementation in locating such bottlenecks and fix the underlying issue (repeated querying of parameters).