### PR TITLE
more bugfixes for roscore compatibility

### DIFF
--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -62,7 +62,7 @@ impl ClientApi {
         caller_id: &str,
         key: &str,
         value: &Value,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Value> {
         let request = Call::new("paramUpdate", (caller_id, key, value));
         let result = self.client.call(request).await;
         Ok(result?)

--- a/src/core.rs
+++ b/src/core.rs
@@ -986,13 +986,13 @@ impl Handler for GetParamHandler {
         log::debug!("GetParamHandler {:?} ", params);
         type Request = (String, String);
         let (caller_id, key) = Request::try_from_params(params)?;
-        let key = resolve(&caller_id, &key);
+        let key_full = resolve(&caller_id, &key);
         let params = self.data.parameters.read().unwrap();
-        let key = key.strip_prefix('/').unwrap_or(&key).split('/');
+        let key_path = key_full.strip_prefix('/').unwrap_or(&key_full).split('/');
 
-        Ok(match params.get(key) {
-            Some(value) => (1, "", value.to_owned()),
-            None => (0, "", Value::string("".to_owned())),
+        Ok(match params.get(key_path) {
+            Some(value) => (1, "".to_owned(), value.to_owned()),
+            None => (-1, format!("Parameter [{key_full}] is not set"), Value::i4(0)),
         }
         .try_to_value()?)
     }


### PR DESCRIPTION
changes:

- return correct error when querying a missing parameter (previously, this would show up as a `rospy.core.rosgraph.MasterError` in the rospy API)
- when param subscribers return (1, "", 0) instead of (), don't treat that as an error (apparently some clients do this)
- make topic type mismatch a soft error, allow subscribing to `*` type (fixes rosbag record. upstream roscore allows using different types on the same topic. `*` is used when a subscriber doesn't care about the exact type, like rosbag. When a subscriber tries to connect to an incompatible publisher, this results in a warning on the client's side when using rospy, and is not handled by roscore. The previous behavior of ros-core-rs would be that the subscriber's API call fails entirely, which is different than what roscore does.)
