### PR TITLE
compatibility with old roscpp using dxr/quick-xml fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,3 @@ tokio-util = "0.7.8"
 
 [features]
 doctest = []
-
-[patch.crates-io]
-dxr = { path = "../dxr/dxr" }
-dxr_server = { path = "../dxr/dxr_server"}
-dxr_client = { path = "../dxr/dxr_client"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,9 @@ keywords = ["ros", "rosrust", "roscore", "robotics"]
 categories = ["science::robotics"]
 
 [dependencies]
-dxr = { version = "0.6.3" }
-dxr_server = { version = "0.6.3", features = ["axum", "multicall"] }
-dxr_client = { version = "0.6.3", default-features = false, features = [
+dxr = { version = "0.7.0" }
+dxr_server = { version = "0.7.0", features = ["axum", "multicall"] }
+dxr_client = { version = "0.7.0", default-features = false, features = [
     "reqwest",
     "rustls-tls" # Use rustls instead of openssl for easier cross-compilation
 ] }
@@ -38,3 +38,8 @@ tokio-util = "0.7.8"
 
 [features]
 doctest = []
+
+[patch.crates-io]
+dxr = { path = "../dxr/dxr" }
+dxr_server = { path = "../dxr/dxr_server"}
+dxr_client = { path = "../dxr/dxr_client"}

--- a/src/client_api.rs
+++ b/src/client_api.rs
@@ -1,5 +1,5 @@
 use dxr::Value;
-use dxr_client::{Call, Client, ClientBuilder, Url};
+use dxr_client::{Client, ClientBuilder, Url};
 
 pub struct ClientApi {
     client: Client,
@@ -41,8 +41,8 @@ impl ClientApi {
         topic: &str,
         publisher_apis: &Vec<String>,
     ) -> anyhow::Result<Value> {
-        let request = Call::new("publisherUpdate", (caller_id, topic, publisher_apis));
-        let result = self.client.call::<_, _>(request).await;
+        let result = self.client.call::<_, _>("publisherUpdate", (caller_id, topic, publisher_apis)).await;
+        
         Ok(result?)
     }
 
@@ -63,8 +63,7 @@ impl ClientApi {
         key: &str,
         value: &Value,
     ) -> anyhow::Result<Value> {
-        let request = Call::new("paramUpdate", (caller_id, key, value));
-        let result = self.client.call(request).await;
+        let result = self.client.call("paramUpdate", (caller_id, key, value)).await;
         Ok(result?)
     }
 
@@ -84,8 +83,7 @@ impl ClientApi {
         caller_id: &str,
         reason: &str,
     ) -> anyhow::Result<()> {
-        let request = Call::new("shutdown", (caller_id, reason));
-        let result = self.client.call(request).await;
+        let result = self.client.call("shutdown", (caller_id, reason)).await;
         Ok(result?)
     }
 }

--- a/src/core.rs
+++ b/src/core.rs
@@ -1,5 +1,5 @@
 extern crate dxr;
-use dxr_client::{Call, Client, ClientBuilder, Url};
+use dxr_client::{Client, ClientBuilder, Url};
 use maplit::hashmap;
 use paste::paste;
 use std::collections::hash_map::Entry;
@@ -1011,7 +1011,7 @@ impl Handler for GetParamHandler {
         let key_path = key_full.strip_prefix('/').unwrap_or(&key_full).split('/');
 
         Ok(match params.get(key_path) {
-            Some(value) => (1, "".to_owned(), value.to_owned()),
+            Some(value) => (1, format!("Parameter [{}]", &key_full), value.to_owned()),
             None => (-1, format!("Parameter [{key_full}] is not set"), Value::i4(0)),
         }
         .try_to_value()?)
@@ -1423,11 +1423,11 @@ macro_rules! implement_client_fn {
     ($name:ident($($v:ident: $t:ty),*)->$response_type:ident) => {
         paste!{
             pub async fn [<$name:snake>](&self, $($v: $t),*) -> anyhow::Result<$response_type>{
-                let request = Call::new(
+                let request = (
                     MasterEndpoints::$name.as_str(),
                     ($($v,)*),
                 );
-                let response = self.client.call(request).await?;
+                let response = self.client.call(request.0, request.1).await?;
                 let value = $response_type::try_from_value(&response)?;
                 Ok(value)
             }

--- a/src/core.rs
+++ b/src/core.rs
@@ -1012,7 +1012,7 @@ impl Handler for GetParamHandler {
 
         Ok(match params.get(key_path) {
             Some(value) => (1, format!("Parameter [{}]", &key_full), value.to_owned()),
-            None => (-1, format!("Parameter [{key_full}] is not set"), Value::i4(0)),
+            None => (-1, format!("Parameter [{}] is not set", &key_full), Value::i4(0)),
         }
         .try_to_value()?)
     }


### PR DESCRIPTION
The previously used version of `quick-xml` (dependency of `dxr`) sometimes emitted self-closing XML tags (like `<this />`), instead of the longer form (`<this></this>`). which is not supported by some versions of roscpp (causing a C++ exception). While `quick-xml` has an option called `expand_empty_elements`, which `dxr` uses (because apparently handling self-closing tags is a known issue in xmlrpc libraries), that option was not always respected.

Dxr has now released v0.7, which comes with the fixed quick-xml version and some minor API changes.

Actual underlying fix:
https://github.com/tafia/quick-xml/blame/a5ad85e0020b62182a377338b887e8796ffb0acf/src/se/element.rs#L484

Issue thread on dxr's repo:
https://github.com/ironthree/dxr/pull/23