### PR TITLE
fix interactions between missing/deleted params and param subscription (get_param_cached)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ pub mod client_api;
 pub mod core;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use url::Url;
+use dxr::{TryToValue, Value};
 
 mod param_tree;
 
@@ -33,4 +34,8 @@ pub fn url_to_socket_addr(url: &Url) -> anyhow::Result<SocketAddr> {
     };
     let port = url.port().expect("Invalid URL: no port specified");
     Ok(SocketAddr::new(ip_addr, port))
+}
+
+fn empty_struct() -> Value {
+    std::collections::HashMap::<String, i32>::new().try_to_value().unwrap()
 }


### PR DESCRIPTION
Fixes:
- subscribing to non-existent params (maybe they've not yet been set?) now notifies the subscriber
- deleting a param also notifies the subscriber

<s>Because ROS seems to use the empty struct as the placeholder value for non-existing values in the param tree, for this to work we need a version of dxr that supports creating that value. I have opened a PR there as well.
- https://github.com/ironthree/dxr/pull/25

That would need to be merged first (and a new release made on crates.io) for us to be able to use it in ros-core-rs.

Edit: failing CI is expected at the moment, due to the required change in dxr's API.</s>

Edit 2: @decathorpe [pointed out a way](https://github.com/ironthree/dxr/issues/24#issuecomment-2585794128) to create an empty struct without changing dxr's API, so I changed the code accordingly.

The remaining build failure is unrelated and seems to be caused by some version of xml-rs having been yanked. This [affects rosrust as well](https://github.com/adnanademovic/rosrust/issues/210), and is unrelated to this change. You can still build with an old `Cargo.lock` file in place.

Edit 3: The build with rust nightly is broken as well (for the same reason), I don't know why this shows up as green though.