### PR TITLE
Improve contains perf

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -1281,13 +1281,7 @@ impl Handler for HasParamHandler {
         type Request = (String, String);
         let (caller_id, key) = Request::try_from_params(params)?;
         let key = resolve(&caller_id, &key);
-        let has = self
-            .data
-            .parameters
-            .read()
-            .unwrap()
-            .get_keys()
-            .contains(&key);
+        let has = self.data.parameters.read().unwrap().contains(key);
         Ok((1, "", has).try_to_value()?)
     }
 }

--- a/src/param_tree.rs
+++ b/src/param_tree.rs
@@ -57,7 +57,7 @@ impl ParamValue {
     }
 
     pub(crate) fn contains(&self, key: String) -> bool {
-        let key = key.split('/').collect::<Vec<_>>();
+        let key = key.split('/');
         self.get(key).is_some()
     }
 
@@ -175,4 +175,8 @@ fn test_param_tree() {
     tree.update_inner(["robot_configs"].iter(), Value::i4(23));
     let res = tree.get(["robot_configs"]).unwrap();
     assert_eq!(res, Value::i4(23));
+
+    assert!(tree.contains("/".to_owned()));
+    assert!(tree.contains("/arms".to_owned()));
+    assert!(tree.contains("/arms/arm_left".to_owned()));
 }

--- a/src/param_tree.rs
+++ b/src/param_tree.rs
@@ -55,6 +55,12 @@ impl ParamValue {
             _ => Vec::new(),
         }
     }
+
+    pub(crate) fn contains(&self, key: String) -> bool {
+        let key = key.split('/').collect::<Vec<_>>();
+        self.get(key).is_some()
+    }
+
     pub(crate) fn get<I, T>(&self, key: I) -> Option<Value>
     where
         I: IntoIterator<Item = T>,


### PR DESCRIPTION
This repo is awesome :). I was trying it out and I did however notice that the performance isn't as good as the original python version when you have large ROS state. I added some support for `tracing_tracy` and some `criterion` benchmarks but those are a bit messy. Running the benchmarks, I saw that this function can be very slow which makes `GetParamHandler::handle` slow. This change should have exactly the same behaviour but avoids having to recurse through the entire param tree (I've added a few extra tests to verify this). For complex trees the speedup can be more than 50x.

```
contains/simple_tree_existing
                        time:   [56.041 ns 56.090 ns 56.153 ns]
                        change: [-44.979% -44.674% -44.450%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  1 (1.00%) low severe
  3 (3.00%) high mild
  1 (1.00%) high severe
contains/simple_tree_missing
                        time:   [31.750 ns 31.967 ns 32.260 ns]
                        change: [-70.381% -70.271% -70.113%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  5 (5.00%) high mild
  7 (7.00%) high severe
contains/complex_tree_shallow
                        time:   [48.286 ns 48.424 ns 48.636 ns]
                        change: [-98.452% -98.449% -98.444%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low mild
  2 (2.00%) high mild
  3 (3.00%) high severe
contains/complex_tree_deep
                        time:   [106.85 ns 107.09 ns 107.43 ns]
                        change: [-96.562% -96.558% -96.552%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) low severe
  3 (3.00%) high mild
  2 (2.00%) high severe
contains/complex_tree_missing
                        time:   [89.958 ns 90.094 ns 90.268 ns]
                        change: [-97.102% -97.095% -97.086%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  1 (1.00%) low mild
  5 (5.00%) high mild
  6 (6.00%) high severe
```