### PR TITLE
Fix LookupServiceHandler error string formatting

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -811,7 +811,7 @@ impl Handler for LookupServiceHandler {
             if services.is_empty() {
                 return Ok((
                     0,
-                    "`no providers for service \"{service}\"`".to_string(),
+                    format!("`no providers for service \"{service}\"`"),
                     "",
                 )
                     .try_to_value()?);
@@ -823,7 +823,7 @@ impl Handler for LookupServiceHandler {
 
         return Ok((
             0,
-            "`no providers for service \"{service}\"`".to_string(),
+            format!("`no providers for service \"{service}\"`"),
             "",
         )
             .try_to_value()?);


### PR DESCRIPTION
A very small bugfix, ensures that the service name is properly injected into the `lookupService` endpoint's error response.